### PR TITLE
Retirar Tela Painel para as Subunidades

### DIFF
--- a/emendas/classes/model/Siconv.inc
+++ b/emendas/classes/model/Siconv.inc
@@ -151,7 +151,7 @@ class Emendas_Model_Siconv extends Modelo
             if(is_array($pareceres)){
                 foreach($pareceres as $parecer){
 
-                    $sql = "select * from emendas.siconvparecer where idhash = '{$parecer->idHash}' and sicid = '{$sicid}'";
+                    $sql = "select * from emendas.siconvparecer where idhash = '{$parecer->idHash}' and sicid = '". (int)$sicid. "'";
                     $spaid = $this->pegaUm($sql);
 
                     $mSiconvParecer = new Emendas_Model_SiconvParecer($spaid);

--- a/emendas/modulos/inicio.inc
+++ b/emendas/modulos/inicio.inc
@@ -1,6 +1,23 @@
 <?php
 
-//simec_redirecionar('emendas.php?modulo=principal/emenda&acao=A');
+# Busca perfis do usuário logado
+$perfis = pegaPerfilGeral();
+
+# Caso seja o perfil de SubUnidade o sistema redireciona para a tela de lista de emendas.
+if(count(array_intersect($perfis, [PFL_SUBUNIDADE]))){
+    # Todos os perfis são redirecionados para a nova tela de Painel
+    $urlPainel = 'emendas.php?modulo=principal/emenda&acao=A';
+    if($_REQUEST['exercicio']){
+        $urlPainel .= '&exercicio='. $_REQUEST['exercicio'];
+    }
+    if($_REQUEST['req']){
+        $urlPainel .= '&req='. $_REQUEST['req'];
+    }
+    if($_REQUEST['pliid']){
+        $urlPainel .= '&pliid='. $_REQUEST['pliid'];
+    }
+    simec_redirecionar($urlPainel);
+}
 
 $mEmendas = new Emendas_Model_Emenda();
 

--- a/emendas/modulos/principal/emenda.inc
+++ b/emendas/modulos/principal/emenda.inc
@@ -33,7 +33,7 @@ include APPRAIZ . "includes/cabecalho.inc";
                     <?php endif; ?>
 
                     <div class="table-responsive">
-                        <table class="table table-striped table-bordered table-hover dataTables" >
+                        <table class="table table-bordered table-hover dataTablesSP" >
                             <thead>
                             <tr class="text-center">
                                 <th width="5%">Ações</th>
@@ -70,3 +70,18 @@ include APPRAIZ . "includes/cabecalho.inc";
         </div>
     </div>
 </div>
+
+<script>
+    $(document).ready(function(){
+
+        $('.dataTablesSP').DataTable({
+            bPaginate: false,
+            responsive: true,
+            dom: '<"html5buttons"B>lTfgitp',
+            "language": {
+                "url": "/zimec/public/temas/simec/js/plugins/dataTables/Portuguese-Brasil.json"
+            }
+        });
+        
+    });
+</script>

--- a/seguranca/www/scripts_exec/spo_consultaSiconv.php
+++ b/seguranca/www/scripts_exec/spo_consultaSiconv.php
@@ -64,7 +64,7 @@ include_once APPRAIZ . "emendas/classes/model/SiconvPrograma.inc";
 include_once APPRAIZ . "emendas/classes/model/SiconvSituacao.inc";
 include_once APPRAIZ . "emendas/classes/model/SiconvBeneficiario.inc";
 include_once APPRAIZ . "siconv/classes/model/PropostaWs.inc";
-include_once APPRAIZ . "emenda\classes\WSIntegracaoSiconv.class.inc";
+include_once APPRAIZ . "emenda/classes/WSIntegracaoSiconv.class.inc";
 
 $exercicio = date('Y');
 


### PR DESCRIPTION
Correção pras Unidades não verem os dados gerais do sistema.
Retirando paginação da tela de lista de emendas.
Correção serviço SICONV.