### PR TITLE
[UPDATE]Cadastro Complementar do PI-Gerar PI. Issue #606

### DIFF
--- a/emendas/classes/controller/Beneficiario.inc
+++ b/emendas/classes/controller/Beneficiario.inc
@@ -14,6 +14,7 @@ class Emendas_Controller_Beneficiario
             $mBeneficiario->benconveniado = $dados['benconveniado'] == 't' ? 't' : 'f';
             $mBeneficiario->benpago = $dados['benpago'] == 't' ? 't' : 'f';
             $mBeneficiario->bented = $dados['bented'] == 't' ? 't' : 'f';
+            $mBeneficiario->plititulo = substr($dados['plititulo'], 0, 230);
 
             $aCamposNulos = [
                 # Cadastro Inicial


### PR DESCRIPTION
Inserindo restrição de caracteres e alterando o formato do campo do banco de titulo para evitar problemas futuros na integração com o módulo Planejamento Orçamentário através da funcionalidade Gerar PI.