### PR TITLE
[CORREÇÃO]Painel - Cadastro de Indicadores

### DIFF
--- a/painel/classes/controller/Indicador.inc
+++ b/painel/classes/controller/Indicador.inc
@@ -7,7 +7,7 @@ class Painel_Controller_Indicador
         try {
             $mIndicador = new Painel_Model_Indicador($dados['indid']);
             $mIndicador->popularDadosObjeto($dados);
-            $mIndicador->salvar(null, null, null);
+            $mIndicador->salvar(null, null, ['indobsgestor', 'indavalgestor']);
             $mIndicador->commit();
             return true;
         } catch (Exception $e){

--- a/painel/modulos/principal/cadastro.inc
+++ b/painel/modulos/principal/cadastro.inc
@@ -132,8 +132,6 @@ if( (isset($_REQUEST[evento]) && ($_REQUEST[evento] != '')) || $_SESSION['indid'
 				$mtiid 				= $_REQUEST['mtiid'];
 				$indshformula		= $_REQUEST['indshformula'];
 				$formulash			= $_REQUEST['formulash'];
-				$indavalgestor			= $_REQUEST['indavalgestor'];
-				$indobsgestor			= $_REQUEST['indobsgestor'];
 				if($indpublicado=='true'){
 					$indhomologado = true;
 				}
@@ -178,13 +176,12 @@ if( (isset($_REQUEST[evento]) && ($_REQUEST[evento] != '')) || $_SESSION['indid'
 							  indformula, indtermos, indfontetermo, indnormalinicio, indnormalfinal, indatencaoinicio,
 							  indatencaofinal, indcriticoinicio, indcriticofinal, indmetavalor, indmetadatalimite,exoid,regid,umeid,
                                                           indqtdevalor,indcumulativo,indpublicado,indescala,indobservacao,peridatual,indcumulativovalor,indpublico,
-                                                          indhomologado,mtiid,indshformula,formulash,indencerrado,indavalgestor, indobsgestor)
+                                                          indhomologado,mtiid,indshformula,formulash,indencerrado)
 						  VALUES 
 						  	   (".$unmid.", ".$cliid.", ".$tpiid.", ".$secid.", ".$secidgestora.", ".$acaid.", ".$perid.", ".$estid.", ".$colid.", '".$usucpf."', '".$indnome."', '".$indobjetivo."',
 							  '".$indformula."', '".$indtermos."', '".$indfontetermo."', ".$indnormalinicio.", ".$indnormalfinal.", ".$indatencaoinicio.",
 							  ".$indatencaofinal.", ".$indcriticoinicio.", ".$indcriticofinal.", ".$indmetavalor.", '".$indmetadatalimite."','".$exoid."',$regid,$umeid,$indqtdevalor,'$indcumulativo',"
-                                        . "               $indpublicado,$indescala,'$indobservacao','$peridatual','$indcumulativovalor',$indpublico,$indhomologado,$mtiid,$indshformula,'$formulash',$indencerrado,
-                                                          '$indavalgestor', '$indobsgestor')
+                                        . "               $indpublicado,$indescala,'$indobservacao','$peridatual','$indcumulativovalor',$indpublico,$indhomologado,$mtiid,$indshformula,'$formulash',$indencerrado)
 						  RETURNING	indid
 						  ";
 			
@@ -258,9 +255,7 @@ if( (isset($_REQUEST[evento]) && ($_REQUEST[evento] != '')) || $_SESSION['indid'
                                          indencerrado = 		".($indencerrado=='' ? 'indencerrado' : "'".$indencerrado."'").",
                                          mtiid = $mtiid,
                                          indshformula = $indshformula,
-                                         formulash = '$formulash',
-                                         indavalgestor = '$indavalgestor',
-                                         indobsgestor = '$indobsgestor'
+                                         formulash = '$formulash'
                                         WHERE indid = 			".$indid."	
                                 ";
 


### PR DESCRIPTION
Permitir apagar observação da avaliação dos indicadores e não apagar as observações da avaliação do gestor ao salvar o cadastro do indicador.